### PR TITLE
Remove header text while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                     <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>


### PR DESCRIPTION
This PR removes the header text as requested in issue #2.

**Changes:**
- Removed "Course Materials Assistant" header
- Removed "Ask questions about courses, instructors, and content" subheader
- Preserved theme toggle functionality

Fixes #2

Generated with [Claude Code](https://claude.ai/code)